### PR TITLE
Only use port 3048 for production

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -7,6 +7,8 @@ services:
             FLASK_ENV: development
             FLASK_DEBUG: 1
             FLASK_APP: run:flask
-        command: flask run --host=0.0.0.0 --port=3048
+        command: flask run --host=0.0.0.0 --port=3000
         volumes:
             - ./app:/app/app
+        ports:
+            - "3000:3000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,6 @@ services:
             - .env
         volumes:
             - ./db.sqlite3:/app/db.sqlite3
-        command: gunicorn --workers=2 --bind 0.0.0.0:3048 wsgi:app
+        command: gunicorn --workers=2 --bind 0.0.0.0:3000 wsgi:app
         ports:
-            - "3048:3048"
+            - "3048:3000"


### PR DESCRIPTION
Follow up to #1, this changes the ports so that port 3000 (the Flask default) is used for local development, but 3048 is the only port used in production (so it doesn't conflict with existing services). 
